### PR TITLE
Reach 100% Code Coverage on Tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ dep_xref_runner = git https://github.com/inaka/xref_runner.git 0.2.2
 
 include erlang.mk
 
-LOCAL_DEPS := tools compiler syntax_tools common_test inets test_server dialyzer wx mnesia
+LOCAL_DEPS := tools compiler syntax_tools common_test crypto inets test_server dialyzer wx mnesia
 DIALYZER_DIRS := ebin/ test/
 DIALYZER_OPTS := --verbose --statistics -Wunmatched_returns
 

--- a/src/sr_entities_handler.erl
+++ b/src/sr_entities_handler.erl
@@ -11,6 +11,7 @@
         , handle_post/2
         ]).
 -export([ announce_req/2
+        , handle_post/3
         ]).
 
 -type options() :: #{ path => string()
@@ -96,17 +97,8 @@ handle_post(Req, State) ->
       {false, Req3, State}
   end.
 
--spec announce_req(cowboy_req:req(), options()) -> cowboy_req:req().
-announce_req(Req, #{verbose := true}) ->
-  {Method, Req1} = cowboy_req:method(Req),
-  {Path,   Req2} = cowboy_req:path(Req1),
-  _ = error_logger:info_msg("~s ~s", [Method, Path]),
-  Req2;
-announce_req(Req, _Opts) -> Req.
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%%% Auxiliary Functions
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+-spec handle_post(sumo:user_doc(), cowboy_req:req(), state()) ->
+  {{true, binary()}, cowboy_req:req(), state()}.
 handle_post(Entity, Req1, State) ->
   #{opts := #{model := Model, path := Path}} = State,
   case erlang:function_exported(Model, id, 1) of
@@ -126,6 +118,18 @@ handle_post(Entity, Req1, State) ->
   Req2 = cowboy_req:set_resp_body(ResBody, Req1),
   Location = iolist_to_binary([Path, Model:uri_path(PersistedEntity)]),
   {{true, Location}, Req2, State}.
+
+-spec announce_req(cowboy_req:req(), options()) -> cowboy_req:req().
+announce_req(Req, #{verbose := true}) ->
+  {Method, Req1} = cowboy_req:method(Req),
+  {Path,   Req2} = cowboy_req:path(Req1),
+  _ = error_logger:info_msg("~s ~s", [Method, Path]),
+  Req2;
+announce_req(Req, _Opts) -> Req.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% Auxiliary Functions
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 -spec atom_to_method(get|put|post|delete) -> binary().
 atom_to_method(get) -> <<"GET">>;

--- a/src/sr_entities_handler.erl
+++ b/src/sr_entities_handler.erl
@@ -11,7 +11,6 @@
         , handle_post/2
         ]).
 -export([ announce_req/2
-        , handle_exception/3
         ]).
 
 -type options() :: #{ path => string()
@@ -94,8 +93,7 @@ handle_post(Req, State) ->
       {halt, Req3, State};
     _:badjson ->
       Req3 = cowboy_req:set_resp_body(<<"Malformed JSON request">>, Req),
-      {false, Req3, State};
-    _:Exception -> handle_exception(Exception, Req, State)
+      {false, Req3, State}
   end.
 
 -spec announce_req(cowboy_req:req(), options()) -> cowboy_req:req().
@@ -105,22 +103,6 @@ announce_req(Req, #{verbose := true}) ->
   _ = error_logger:info_msg("~s ~s", [Method, Path]),
   Req2;
 announce_req(Req, _Opts) -> Req.
-
--spec handle_exception(term(), cowboy_req:req(), state()) ->
-    {halt, cowboy_req:req(), state()}.
-handle_exception(Reason, Req, State) ->
-  _ =
-    error_logger:error_msg(
-      "~p. Stack Trace: ~s", [Reason, ktn_debug:ppst()]),
-  {ok, Req1} =
-    try cowboy_req:reply(500, Req)
-    catch
-      _:Error ->
-        Msg = "~p trying to report error through cowboy. Stack Trace: ~s",
-        error_logger:error_msg(Msg, [Error, ktn_debug:ppst()]),
-        {ok, Req}
-    end,
-  {halt, Req1, State}.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Auxiliary Functions

--- a/src/sr_json.erl
+++ b/src/sr_json.erl
@@ -3,6 +3,7 @@
 
 -export([encode/1, decode/1]).
 -export([encode_date/1, decode_date/1]).
+-export([encode_null/1, decode_null/1]).
 
 -type key() :: binary() | atom().
 -type object() :: #{key() => json()}.
@@ -11,17 +12,19 @@
               | binary()
               | number()
               | boolean()
-              | null.
+              | null
+              .
+-type non_null_json() :: object()
+                       | [object()]
+                       | binary()
+                       | number()
+                       | boolean()
+                       .
 
 -export_type([json/0]).
 
 -spec encode(json()) -> iodata().
-encode(Json) ->
-  try jiffy:encode(Json, [uescape])
-  catch
-    _:_Error ->
-      throw(notjson)
-  end.
+encode(Json) -> jiffy:encode(Json, [uescape]).
 
 -spec decode(iodata()) -> json().
 decode(Data) ->
@@ -37,3 +40,13 @@ encode_date(DateTime) -> iso8601:format(DateTime).
 %% @todo remove binary_to_list when is8601 specs are fixed
 -spec decode_date(binary()) -> calendar:datetime().
 decode_date(DateTime) -> iso8601:parse(binary_to_list(DateTime)).
+
+-spec encode_null(undefined) -> null
+               ; (json()) -> json().
+encode_null(undefined) -> null;
+encode_null(Json) -> Json.
+
+-spec decode_null(null) -> undefined
+               ; (non_null_json()) -> json().
+decode_null(null) -> undefined;
+decode_null(Json) -> Json.

--- a/src/sr_single_entity_handler.erl
+++ b/src/sr_single_entity_handler.erl
@@ -98,9 +98,9 @@ delete_resource(Req, State) ->
 %%% Auxiliary Functions
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 from_json(Model, Id, Json) ->
-  case erlang:function_exported(Model, from_json, 2) of
-    true -> Model:from_json(Id, Json);
-    false -> Model:from_json(Json)
+  try Model:from_json(Id, Json)
+  catch
+    _:undef -> Model:from_json(Json)
   end.
 
 handle_put({error, Reason}, Req, State) ->

--- a/src/sr_single_entity_handler.erl
+++ b/src/sr_single_entity_handler.erl
@@ -7,7 +7,6 @@
           , allowed_methods/2
           , content_types_provided/2
           , announce_req/2
-          , handle_exception/3
           ]
         }]).
 
@@ -74,8 +73,7 @@ handle_put(Req, #{entity := Entity} = State) ->
   catch
     _:badjson ->
       Req3 = cowboy_req:set_resp_body(<<"Malformed JSON request">>, Req),
-      {false, Req3, State};
-    _:Exception -> handle_exception(Exception, Req, State)
+      {false, Req3, State}
   end;
 handle_put(Req, #{id := Id} = State) ->
   #{opts := #{model := Model}} = State,
@@ -86,20 +84,15 @@ handle_put(Req, #{id := Id} = State) ->
   catch
     _:badjson ->
       Req3 = cowboy_req:set_resp_body(<<"Malformed JSON request">>, Req),
-      {false, Req3, State};
-    _:Exception -> handle_exception(Exception, Req, State)
+      {false, Req3, State}
   end.
 
 -spec delete_resource(cowboy_req:req(), state()) ->
   {boolean() | halt, cowboy_req:req(), state()}.
 delete_resource(Req, State) ->
   #{opts := #{model := Model}, id := Id} = State,
-  try
-    Result = sumo:delete(Model, Id),
-    {Result, Req, State}
-  catch
-    _:Exception -> handle_exception(Exception, Req, State)
-  end.
+  Result = sumo:delete(Model, Id),
+  {Result, Req, State}.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Auxiliary Functions

--- a/src/sumo_rest_doc.erl
+++ b/src/sumo_rest_doc.erl
@@ -23,7 +23,9 @@
 -callback from_json(json()) -> {ok, entity()} | {error, reason()}.
 -callback update(entity(), json()) -> {ok, entity()} | {error, reason()}.
 -callback uri_path(entity()) -> iodata().
-%% @todo optional callback (it's only needed if dups should raise 409 conflict)
+%% @doc it's only needed if dups should raise 409 conflict
 -callback id(entity()) -> term().
-%% @todo optional callback (it's only needed if ids are not coming in PUT jsons)
+%% @doc it's only needed if ids are not coming in PUT jsons
 -callback from_json(binary(), json()) -> {ok, entity()} | {error, reason()}.
+
+-optional_callbacks([id/1, from_json/2]).

--- a/test/sr_elements_SUITE.erl
+++ b/test/sr_elements_SUITE.erl
@@ -169,6 +169,7 @@ invalid_headers(_Config) ->
 -spec invalid_parameters(sr_test_utils:config()) -> {comment, string()}.
 invalid_parameters(_Config) ->
   Headers = #{<<"content-type">> => <<"application/json">>},
+  _ = sumo:persist(sr_elements, sr_elements:new(<<"key">>, <<"val">>)),
 
   ct:comment("Empty or broken parameters are reported"),
   #{status_code := 400} =
@@ -176,9 +177,13 @@ invalid_parameters(_Config) ->
   #{status_code := 400} =
     sr_test_utils:api_call(put, "/elements/nobody", Headers, <<>>),
   #{status_code := 400} =
+    sr_test_utils:api_call(put, "/elements/key", Headers, <<>>),
+  #{status_code := 400} =
     sr_test_utils:api_call(post, "/elements", Headers, <<"{">>),
   #{status_code := 400} =
     sr_test_utils:api_call(put, "/elements/broken", Headers, <<"{">>),
+  #{status_code := 400} =
+    sr_test_utils:api_call(put, "/elements/key", Headers, <<"{">>),
 
   ct:comment("Missing parameters are reported"),
   None = #{},
@@ -186,12 +191,16 @@ invalid_parameters(_Config) ->
     sr_test_utils:api_call(post, "/elements", Headers, None),
   #{status_code := 400} =
     sr_test_utils:api_call(put, "/elements/none", Headers, None),
+  #{status_code := 400} =
+    sr_test_utils:api_call(put, "/elements/key", Headers, None),
 
   NoVal = #{key => <<"noval">>},
   #{status_code := 400} =
     sr_test_utils:api_call(post, "/elements", Headers, NoVal),
   #{status_code := 400} =
     sr_test_utils:api_call(put, "/elements/noval", Headers, NoVal),
+  #{status_code := 400} =
+    sr_test_utils:api_call(put, "/elements/key", Headers, NoVal),
 
   {comment, ""}.
 

--- a/test/sr_elements_SUITE.erl
+++ b/test/sr_elements_SUITE.erl
@@ -68,7 +68,8 @@ success_scenario(_Config) ->
   #{status_code := 200, body := Body3} =
     sr_test_utils:api_call(
       put, "/elements/element1", Headers,
-      #{ value => <<"newval1">>
+      #{ key => <<"element1">>
+       , value => <<"newval1">>
        }),
   #{ <<"key">>        := <<"element1">>
    , <<"created_at">> := CreatedAt
@@ -85,7 +86,9 @@ success_scenario(_Config) ->
   #{status_code := 201, body := Body5} =
     sr_test_utils:api_call(
       put, "/elements/element2", Headers,
-      #{value => <<"val2">>}),
+      #{ key => <<"element2">>
+       , value => <<"val2">>
+       }),
   #{ <<"key">>        := <<"element2">>
    , <<"created_at">> := CreatedAt5
    , <<"updated_at">> := CreatedAt5

--- a/test/sr_json_SUITE.erl
+++ b/test/sr_json_SUITE.erl
@@ -1,0 +1,63 @@
+-module(sr_json_SUITE).
+
+-export([all/0]).
+-export([ jsons/1
+        , dates/1
+        , nulls/1
+        ]).
+
+-spec all() -> [atom()].
+all() -> sr_test_utils:all(?MODULE).
+
+-spec jsons(sr_test_utils:config()) -> {comment, string()}.
+jsons(_Config) ->
+  WorksWith =
+    fun(Json) ->
+      ct:comment("Works with ~s", [Json]),
+      Json = sr_json:encode(sr_json:decode(Json))
+    end,
+  Jsons =
+    [ <<"null">>
+    , <<"true">>
+    , <<"false">>
+    , <<"1">>
+    , <<"0.3">>
+    , <<"\"a string\"">>
+    , <<"[true,true,false]">>
+    , <<"{\"c\":[1,2,3],\"a\":\"b\"}">>
+    ],
+  lists:foreach(WorksWith, Jsons),
+
+  ct:comment("Properly fails to decode {"),
+  try sr_json:decode(<<"{">>) of
+    R -> ct:fail("Unexpected result: ~p", [R])
+  catch
+    throw:badjson -> ok
+  end,
+
+  {comment, ""}.
+
+-spec dates(sr_test_utils:config()) -> {comment, string()}.
+dates(_Config) ->
+  Now = calendar:universal_time(),
+  ct:comment("Encodes ~p", [Now]),
+
+  Now = sr_json:decode_date(sr_json:encode_date(Now)),
+
+  {comment, ""}.
+
+-spec nulls(sr_test_utils:config()) -> {comment, string()}.
+nulls(_Config) ->
+  ct:comment("Encodes undefined as null"),
+  null = sr_json:encode_null(undefined),
+
+  ct:comment("Leaves the rest untouched"),
+  #{} = sr_json:encode_null(#{}),
+
+  ct:comment("Decodes null as undefined"),
+  undefined = sr_json:decode_null(null),
+
+  ct:comment("Leaves the rest untouched"),
+  #{} = sr_json:decode_null(#{}),
+
+  {comment, ""}.

--- a/test/sr_sessions_SUITE.erl
+++ b/test/sr_sessions_SUITE.erl
@@ -15,6 +15,8 @@
 -export([ success_scenario/1
         , invalid_auth/1
         , invalid_headers/1
+        , invalid_parameters/1
+        , conflict/1
         ]).
 
 -spec all() -> [atom()].
@@ -44,9 +46,10 @@ success_scenario(Config) ->
 
   ct:comment("A session is created"),
   #{status_code := 201, body := Body1} =
-    sr_test_utils:api_call(post, "/sessions", Headers),
+    sr_test_utils:api_call(post, "/sessions", Headers, #{agent => <<"a1">>}),
   #{ <<"id">>           := Session1Id
    , <<"token">>        := Token1
+   , <<"agent">>        := <<"a1">>
    , <<"created_at">>   := CreatedAt1
    , <<"expires_at">>   := ExpiresAt1
    } = sr_json:decode(Body1),
@@ -56,40 +59,57 @@ success_scenario(Config) ->
   [Session1] = sumo:find_all(sr_sessions),
   Token1 = sr_sessions:token(Session1),
 
-  ct:comment("Another session can be created with the same parameters"),
-  #{status_code := 201, body := Body2} =
-    sr_test_utils:api_call(post, "/sessions", Headers),
-  #{ <<"id">>           := Session2Id
-   , <<"token">>        := Token2
-   , <<"created_at">>   := CreatedAt2
+  ct:comment("The session agent can be changed"),
+  #{status_code := 200, body := Body2} =
+    sr_test_utils:api_call(
+      put, "/sessions/" ++ binary_to_list(Session1Id), Headers,
+      #{agent => <<"a2">>}),
+  #{ <<"id">>           := Session1Id
+   , <<"agent">>        := <<"a2">>
+   , <<"created_at">>   := CreatedAt1
    , <<"expires_at">>   := ExpiresAt2
    } = sr_json:decode(Body2),
-  true = ExpiresAt2 >= CreatedAt2,
   true = ExpiresAt2 >= ExpiresAt1,
-  true = CreatedAt2 >= CreatedAt1,
-  case Session2Id of
+
+  ct:comment("Still just one session"),
+  [Session2] = sumo:find_all(sr_sessions),
+
+  ct:comment("Another session can be created with no agent"),
+  #{status_code := 201, body := Body3} =
+    sr_test_utils:api_call(post, "/sessions", Headers, #{}),
+  #{ <<"id">>           := Session3Id
+   , <<"token">>        := Token3
+   , <<"agent">>        := null
+   , <<"created_at">>   := CreatedAt3
+   , <<"expires_at">>   := ExpiresAt3
+   } = sr_json:decode(Body3),
+  true = ExpiresAt3 >= CreatedAt3,
+  ct:pal("~p < ~p ?", [ExpiresAt3, ExpiresAt2]),
+  true = ExpiresAt3 >= ExpiresAt2,
+  true = CreatedAt3 >= CreatedAt1,
+  case Session3Id of
     Session1Id -> ct:fail("Duplicated Session Id: ~p", [Session1Id]);
-    Session2Id -> ok
+    Session3Id -> ok
   end,
-  case Token2 of
+  case Token3 of
     Token1 -> ct:fail("Duplicated token: ~p", [Token1]);
-    Token2 -> ok
+    Token3 -> ok
   end,
 
   ct:comment("There are 2 sessions"),
-  [Session2] = sumo:find_all(sr_sessions) -- [Session1],
+  [Session3] = sumo:find_all(sr_sessions) -- [Session2],
 
-  ct:comment("Session1 is deleted"),
-  Uri1 = binary_to_list(<<"/sessions/", Session1Id/binary>>),
-  #{status_code := 204} = sr_test_utils:api_call(delete, Uri1, Headers),
+  ct:comment("Session2 is deleted"),
+  Uri4 = binary_to_list(<<"/sessions/", Session1Id/binary>>),
+  #{status_code := 204} = sr_test_utils:api_call(delete, Uri4, Headers),
 
   ct:comment("One session again"),
-  [Session2] = sumo:find_all(sr_sessions),
+  [Session3] = sumo:find_all(sr_sessions),
 
   ct:comment("DELETE is not idempotent"),
-  Uri2 = binary_to_list(<<"/sessions/", Session2Id/binary>>),
-  #{status_code := 204} = sr_test_utils:api_call(delete, Uri2, Headers),
-  #{status_code := 404} = sr_test_utils:api_call(delete, Uri2, Headers),
+  Uri5 = binary_to_list(<<"/sessions/", Session3Id/binary>>),
+  #{status_code := 204} = sr_test_utils:api_call(delete, Uri5, Headers),
+  #{status_code := 404} = sr_test_utils:api_call(delete, Uri5, Headers),
 
   ct:comment("There are no sessions"),
   [] = sumo:find_all(sr_sessions),
@@ -100,42 +120,52 @@ success_scenario(Config) ->
 invalid_auth(Config) ->
   Uri = "/sessions",
 
-  ct:comment("Can't use POST nor DELETE without auth"),
+  ct:comment("Can't use POST, PUT nor DELETE without auth"),
   #{status_code := 401} = sr_test_utils:api_call(post, Uri),
+  #{status_code := 401} = sr_test_utils:api_call(put, Uri ++ "/noauth"),
   #{status_code := 401} = sr_test_utils:api_call(delete, Uri ++ "/noauth"),
 
-  ct:comment("Can't use POST nor DELETE without Basic auth"),
+  ct:comment("Can't use POST, PUT nor DELETE without Basic auth"),
   Headers1 = #{<<"Authorization">> => <<"Bearer iSnotAGoodThing">>},
   #{status_code := 401} = sr_test_utils:api_call(post, Uri, Headers1),
   #{status_code := 401} =
+    sr_test_utils:api_call(put, Uri ++ "/other", Headers1),
+  #{status_code := 401} =
     sr_test_utils:api_call(delete, Uri ++ "/other", Headers1),
 
-  ct:comment("Can't use POST nor DELETE with broken Basic auth"),
+  ct:comment("Can't use POST, PUT nor DELETE with broken Basic auth"),
   Headers2 = #{<<"Authorization">> => <<"Basic ThisIsNotBase64">>},
   #{status_code := 401} = sr_test_utils:api_call(post, Uri, Headers2),
   #{status_code := 401} =
+    sr_test_utils:api_call(put, Uri ++ "/broken", Headers2),
+  #{status_code := 401} =
     sr_test_utils:api_call(delete, Uri ++ "/broken", Headers2),
 
-  ct:comment("Can't use POST nor DELETE with wrong user"),
+  ct:comment("Can't use POST, PUT nor DELETE with wrong user"),
   Headers3 = #{basic_auth => {"not-user", "pwd"}},
   #{status_code := 401} = sr_test_utils:api_call(post, Uri, Headers3),
   #{status_code := 401} =
+    sr_test_utils:api_call(put, Uri ++ "/not-user", Headers3),
+  #{status_code := 401} =
     sr_test_utils:api_call(delete, Uri ++ "/not-user", Headers3),
 
-  ct:comment("Can't use POST nor DELETE with wrong password"),
+  ct:comment("Can't use POST, PUT nor DELETE with wrong password"),
   {basic_auth, {U, _}} = lists:keyfind(basic_auth, 1, Config),
   Headers4 = #{basic_auth => {U, "not-password"}},
   #{status_code := 401} = sr_test_utils:api_call(post, Uri, Headers4),
   #{status_code := 401} =
+    sr_test_utils:api_call(put, Uri ++ "/wrong-token", Headers4),
+  #{status_code := 401} =
     sr_test_utils:api_call(delete, Uri ++ "/wrong-token", Headers4),
 
-  ct:comment("Sessions can only be deleted by their user"),
+  ct:comment("Sessions can only be modified or deleted by their user"),
   [_, {User2Name, _} | _] = application:get_env(sr_test, users, []),
   SessionId =
     sr_sessions:uri_path(sumo:persist(sr_sessions, sr_sessions:new(User2Name))),
   ForbiddenUri = binary_to_list(<<"/sessions/", SessionId/binary>>),
   {basic_auth, BasicAuth} = lists:keyfind(basic_auth, 1, Config),
   Headers5 = #{basic_auth => BasicAuth},
+  #{status_code := 403} = sr_test_utils:api_call(put, ForbiddenUri, Headers5),
   #{status_code := 403} =
     sr_test_utils:api_call(delete, ForbiddenUri, Headers5),
 
@@ -143,15 +173,73 @@ invalid_auth(Config) ->
 
 -spec invalid_headers(sr_test_utils:config()) -> {comment, string()}.
 invalid_headers(Config) ->
-  Uri = "/sessions",
   {basic_auth, BasicAuth} = lists:keyfind(basic_auth, 1, Config),
+  NoHeaders = #{basic_auth => BasicAuth},
+  InvalidHeaders = #{ basic_auth => BasicAuth
+                    , <<"content-type">> => <<"text/plain">>
+                    },
   InvalidAccept = #{ basic_auth => BasicAuth
                    , <<"content-type">> => <<"application/json">>
                    , <<"accept">> => <<"text/html">>
                    },
 
-  ct:comment("Agent must accept json for POST"),
-  #{status_code := 406} =
-    sr_test_utils:api_call(post, Uri, InvalidAccept, <<>>),
+  [{User, _} | _] = application:get_env(sr_test, users, []),
+  SessionId =
+    sr_sessions:uri_path(sumo:persist(sr_sessions, sr_sessions:new(User))),
+  SessionUri = binary_to_list(<<"/sessions/", SessionId/binary>>),
 
+  ct:comment("content-type must be provided for POST and PUT"),
+  #{status_code := 415} =
+    sr_test_utils:api_call(post, "/sessions", NoHeaders, <<>>),
+  #{status_code := 415} =
+    sr_test_utils:api_call(put, SessionUri, NoHeaders, <<>>),
+
+  ct:comment("content-type must be JSON for POST and PUT"),
+  #{status_code := 415} =
+    sr_test_utils:api_call(post, "/sessions", InvalidHeaders, <<>>),
+  #{status_code := 415} =
+    sr_test_utils:api_call(put, SessionUri, InvalidHeaders, <<>>),
+
+  ct:comment("Agent must accept json for POST and PUT"),
+  #{status_code := 406} =
+    sr_test_utils:api_call(post, "/sessions", InvalidAccept, <<>>),
+  #{status_code := 406} =
+    sr_test_utils:api_call(put, SessionUri, InvalidAccept, <<>>),
+
+  {comment, ""}.
+
+-spec invalid_parameters(sr_test_utils:config()) -> {comment, string()}.
+invalid_parameters(Config) ->
+  {basic_auth, BasicAuth} = lists:keyfind(basic_auth, 1, Config),
+  Headers = #{ basic_auth => BasicAuth
+              , <<"content-type">> => <<"application/json">>
+              },
+
+  [{User, _} | _] = application:get_env(sr_test, users, []),
+  SessionId =
+    sr_sessions:uri_path(sumo:persist(sr_sessions, sr_sessions:new(User))),
+  SessionUri = binary_to_list(<<"/sessions/", SessionId/binary>>),
+
+  ct:comment("Empty or broken parameters are reported"),
+  #{status_code := 400} =
+    sr_test_utils:api_call(post, "/sessions", Headers, <<>>),
+  #{status_code := 400} =
+    sr_test_utils:api_call(put, SessionUri, Headers, <<>>),
+  #{status_code := 400} =
+    sr_test_utils:api_call(post, "/sessions", Headers, <<"{">>),
+  #{status_code := 400} =
+    sr_test_utils:api_call(put, SessionUri, Headers, <<"{">>),
+
+  {comment, ""}.
+
+-spec conflict(sr_test_utils:config()) -> {comment, string()}.
+conflict(Config) ->
+  {basic_auth, BasicAuth} = lists:keyfind(basic_auth, 1, Config),
+  Headers = #{ basic_auth => BasicAuth
+              , <<"content-type">> => <<"application/json">>
+              },
+
+  ct:comment("Can't update unexisting session"),
+  #{status_code := 409} =
+    sr_test_utils:api_call(put, "/sessions/notfound", Headers, #{}),
   {comment, ""}.

--- a/test/sr_sessions_SUITE.erl
+++ b/test/sr_sessions_SUITE.erl
@@ -1,0 +1,157 @@
+-module(sr_sessions_SUITE).
+
+-include_lib("mixer/include/mixer.hrl").
+
+-mixin([{ sr_test_utils
+        , [ init_per_suite/1
+          , end_per_suite/1
+          ]
+        }]).
+
+-export([ all/0
+        , init_per_testcase/2
+        , end_per_testcase/2
+        ]).
+-export([ success_scenario/1
+        , invalid_auth/1
+        , invalid_headers/1
+        ]).
+
+-spec all() -> [atom()].
+all() -> sr_test_utils:all(?MODULE).
+
+-spec init_per_testcase(atom(), sr_test_utils:config()) ->
+  sr_test_utils:config().
+init_per_testcase(_, Config) ->
+  _ = sumo:delete_all(sr_sessions),
+  [{U, P}|_] = application:get_env(sr_test, users, []),
+  [{basic_auth, {binary_to_list(U), binary_to_list(P)}} | Config].
+
+-spec end_per_testcase(atom(), sr_test_utils:config()) ->
+  sr_test_utils:config().
+end_per_testcase(_, Config) ->
+  Config.
+
+-spec success_scenario(sr_test_utils:config()) -> {comment, string()}.
+success_scenario(Config) ->
+  {basic_auth, BasicAuth} = lists:keyfind(basic_auth, 1, Config),
+  Headers = #{ basic_auth => BasicAuth
+             , <<"content-type">> => <<"application/json">>
+             },
+
+  ct:comment("There are no sessions"),
+  [] = sumo:find_all(sr_sessions),
+
+  ct:comment("A session is created"),
+  #{status_code := 201, body := Body1} =
+    sr_test_utils:api_call(post, "/sessions", Headers),
+  #{ <<"id">>           := Session1Id
+   , <<"token">>        := Token1
+   , <<"created_at">>   := CreatedAt1
+   , <<"expires_at">>   := ExpiresAt1
+   } = sr_json:decode(Body1),
+  true = ExpiresAt1 >= CreatedAt1,
+
+  ct:comment("Session ~s is there", [Session1Id]),
+  [Session1] = sumo:find_all(sr_sessions),
+  Token1 = sr_sessions:token(Session1),
+
+  ct:comment("Another session can be created with the same parameters"),
+  #{status_code := 201, body := Body2} =
+    sr_test_utils:api_call(post, "/sessions", Headers),
+  #{ <<"id">>           := Session2Id
+   , <<"token">>        := Token2
+   , <<"created_at">>   := CreatedAt2
+   , <<"expires_at">>   := ExpiresAt2
+   } = sr_json:decode(Body2),
+  true = ExpiresAt2 >= CreatedAt2,
+  true = ExpiresAt2 >= ExpiresAt1,
+  true = CreatedAt2 >= CreatedAt1,
+  case Session2Id of
+    Session1Id -> ct:fail("Duplicated Session Id: ~p", [Session1Id]);
+    Session2Id -> ok
+  end,
+  case Token2 of
+    Token1 -> ct:fail("Duplicated token: ~p", [Token1]);
+    Token2 -> ok
+  end,
+
+  ct:comment("There are 2 sessions"),
+  [Session2] = sumo:find_all(sr_sessions) -- [Session1],
+
+  ct:comment("Session1 is deleted"),
+  Uri1 = binary_to_list(<<"/sessions/", Session1Id/binary>>),
+  #{status_code := 204} = sr_test_utils:api_call(delete, Uri1, Headers),
+
+  ct:comment("One session again"),
+  [Session2] = sumo:find_all(sr_sessions),
+
+  ct:comment("DELETE is not idempotent"),
+  Uri2 = binary_to_list(<<"/sessions/", Session2Id/binary>>),
+  #{status_code := 204} = sr_test_utils:api_call(delete, Uri2, Headers),
+  #{status_code := 404} = sr_test_utils:api_call(delete, Uri2, Headers),
+
+  ct:comment("There are no sessions"),
+  [] = sumo:find_all(sr_sessions),
+
+  {comment, ""}.
+
+-spec invalid_auth(sr_test_utils:config()) -> {comment, string()}.
+invalid_auth(Config) ->
+  Uri = "/sessions",
+
+  ct:comment("Can't use POST nor DELETE without auth"),
+  #{status_code := 401} = sr_test_utils:api_call(post, Uri),
+  #{status_code := 401} = sr_test_utils:api_call(delete, Uri ++ "/noauth"),
+
+  ct:comment("Can't use POST nor DELETE without Basic auth"),
+  Headers1 = #{<<"Authorization">> => <<"Bearer iSnotAGoodThing">>},
+  #{status_code := 401} = sr_test_utils:api_call(post, Uri, Headers1),
+  #{status_code := 401} =
+    sr_test_utils:api_call(delete, Uri ++ "/other", Headers1),
+
+  ct:comment("Can't use POST nor DELETE with broken Basic auth"),
+  Headers2 = #{<<"Authorization">> => <<"Basic ThisIsNotBase64">>},
+  #{status_code := 401} = sr_test_utils:api_call(post, Uri, Headers2),
+  #{status_code := 401} =
+    sr_test_utils:api_call(delete, Uri ++ "/broken", Headers2),
+
+  ct:comment("Can't use POST nor DELETE with wrong user"),
+  Headers3 = #{basic_auth => {"not-user", "pwd"}},
+  #{status_code := 401} = sr_test_utils:api_call(post, Uri, Headers3),
+  #{status_code := 401} =
+    sr_test_utils:api_call(delete, Uri ++ "/not-user", Headers3),
+
+  ct:comment("Can't use POST nor DELETE with wrong password"),
+  {basic_auth, {U, _}} = lists:keyfind(basic_auth, 1, Config),
+  Headers4 = #{basic_auth => {U, "not-password"}},
+  #{status_code := 401} = sr_test_utils:api_call(post, Uri, Headers4),
+  #{status_code := 401} =
+    sr_test_utils:api_call(delete, Uri ++ "/wrong-token", Headers4),
+
+  ct:comment("Sessions can only be deleted by their user"),
+  [_, {User2Name, _} | _] = application:get_env(sr_test, users, []),
+  SessionId =
+    sr_sessions:uri_path(sumo:persist(sr_sessions, sr_sessions:new(User2Name))),
+  ForbiddenUri = binary_to_list(<<"/sessions/", SessionId/binary>>),
+  {basic_auth, BasicAuth} = lists:keyfind(basic_auth, 1, Config),
+  Headers5 = #{basic_auth => BasicAuth},
+  #{status_code := 403} =
+    sr_test_utils:api_call(delete, ForbiddenUri, Headers5),
+
+  {comment, ""}.
+
+-spec invalid_headers(sr_test_utils:config()) -> {comment, string()}.
+invalid_headers(Config) ->
+  Uri = "/sessions",
+  {basic_auth, BasicAuth} = lists:keyfind(basic_auth, 1, Config),
+  InvalidAccept = #{ basic_auth => BasicAuth
+                   , <<"content-type">> => <<"application/json">>
+                   , <<"accept">> => <<"text/html">>
+                   },
+
+  ct:comment("Agent must accept json for POST"),
+  #{status_code := 406} =
+    sr_test_utils:api_call(post, Uri, InvalidAccept, <<>>),
+
+  {comment, ""}.

--- a/test/sr_test/sr_elements.erl
+++ b/test/sr_test/sr_elements.erl
@@ -36,7 +36,6 @@
   , from_json/1
   , uri_path/1
   , id/1
-  , from_json/2
   , update/2
   ]).
 
@@ -67,10 +66,6 @@ to_json(Element) ->
    , updated_at => sr_json:encode_date(maps:get(updated_at, Element))
    }.
 
--spec from_json(key(), sumo_rest_doc:json()) ->
-  {ok, element()} | {error, iodata()}.
-from_json(Key, Json) -> from_json(Json#{<<"key">> => Key}).
-
 -spec from_json(sumo_rest_doc:json()) -> {ok, element()} | {error, iodata()}.
 from_json(Json) ->
   Now = sr_json:encode_date(calendar:universal_time()),
@@ -92,7 +87,7 @@ from_json(Json) ->
 -spec update(element(), sumo_rest_doc:json()) ->
   {ok, element()} | {error, iodata()}.
 update(Element, Json) ->
-  case from_json(id(Element), Json) of
+  case from_json(Json) of
     {error, Reason} -> {error, Reason};
     {ok, Updates} ->
       UpdatedElement = maps:merge(Element, Updates),

--- a/test/sr_test/sr_elements.erl
+++ b/test/sr_test/sr_elements.erl
@@ -78,8 +78,10 @@ from_json(Json) ->
     { ok
     , #{ key        => maps:get(<<"key">>, Json)
        , value      => maps:get(<<"value">>, Json)
-       , created_at => sr_json:decode_date(maps:get(created_at, Json, Now))
-       , updated_at => sr_json:decode_date(maps:get(updated_at, Json, Now))
+       , created_at =>
+          sr_json:decode_date(maps:get(<<"created_at">>, Json, Now))
+       , updated_at =>
+          sr_json:decode_date(maps:get(<<"updated_at">>, Json, Now))
        }
     }
   catch

--- a/test/sr_test/sr_sessions.erl
+++ b/test/sr_test/sr_sessions.erl
@@ -1,0 +1,138 @@
+%%% @doc Sessions Model
+-module(sr_sessions).
+
+-behaviour(sumo_doc).
+-behaviour(sumo_rest_doc).
+
+-type id() :: string().
+-type token() :: binary().
+-type user() :: string().
+
+-opaque session() ::
+  #{ id => undefined | id()
+   , token => token()
+   , user => user()
+   , created_at => calendar:datetime()
+   , expires_at => calendar:datetime()
+   }.
+
+-export_type(
+  [ session/0
+  , id/0
+  , token/0
+  ]).
+
+-export(
+  [ sumo_schema/0
+  , sumo_wakeup/1
+  , sumo_sleep/1
+  ]).
+-export(
+  [ new/1
+  , id/1
+  , token/1
+  , user/1
+  , expires_at/1
+  ]).
+-export(
+  [ to_json/1
+  , from_json/1
+  , uri_path/1
+  , from_json/2
+  , update/2
+  ]).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% BEHAVIOUR CALLBACKS
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+-spec sumo_schema() -> sumo:schema().
+sumo_schema() ->
+  sumo:new_schema(?MODULE,
+    [ sumo:new_field(id,          string,   [id, not_null])
+    , sumo:new_field(token,       string,   [not_null])
+    , sumo:new_field(user,        string,   [not_null])
+    , sumo:new_field(created_at,  datetime, [not_null])
+    , sumo:new_field(expires_at,  datetime, [not_null])
+    ]).
+
+-spec sumo_sleep(session()) -> sumo:doc().
+sumo_sleep(Session) -> Session.
+
+-spec sumo_wakeup(sumo:doc()) -> session().
+sumo_wakeup(Session) -> Session.
+
+-spec to_json(session()) -> sumo_rest_doc:json().
+to_json(Session) ->
+  #{ id =>
+      case maps:get(id, Session) of
+        undefined -> null;
+        Id -> list_to_binary(Id)
+      end
+   , token => maps:get(token, Session)
+   , created_at => sr_json:encode_date(maps:get(created_at, Session))
+   , expires_at => sr_json:encode_date(maps:get(expires_at, Session))
+   }.
+
+-spec from_json(binary(), sumo_rest_doc:json()) ->
+  {ok, session()} | {error, iodata()}.
+from_json(Id, Json) -> from_json(Json#{<<"id">> => Id}).
+
+-spec from_json(sumo_rest_doc:json()) -> {ok, session()} | {error, iodata()}.
+from_json(Json) ->
+  Now = sr_json:encode_date(calendar:universal_time()),
+  try
+    { ok
+    , #{ id =>
+          case maps:get(<<"id">>, Json, null) of
+            null -> undefined;
+            Id -> binary_to_list(Id)
+          end
+       , token => maps:get(<<"token">>, Json)
+       , created_at =>
+          sr_json:decode_date(maps:get(<<"created_at">>, Json, Now))
+       , expires_at =>
+          sr_json:decode_date(maps:get(<<"expires_at">>, Json, Now))
+       }
+    }
+  catch
+    _:{badkey, Key} ->
+      {error, <<"missing field: ", Key/binary>>}
+  end.
+
+-spec update(session(), sumo_rest_doc:json()) -> no_return().
+update(_Session, _Json) -> throw(should_not_update_session).
+
+-spec uri_path(session()) -> binary().
+uri_path(Session) -> list_to_binary(id(Session)).
+
+-spec id(session()) -> undefined | id().
+id(#{id := Id}) -> Id.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% PUBLIC API
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+-spec new(user()) -> session().
+new(User) ->
+  Now = calendar:universal_time(),
+  ExpiresAt =
+    calendar:gregorian_seconds_to_datetime(
+      calendar:datetime_to_gregorian_seconds(Now) + 60000),
+  #{ id         => undefined
+   , user       => User
+   , token      => generate_token()
+   , created_at => Now
+   , expires_at => ExpiresAt
+   }.
+
+-spec token(session()) -> token().
+token(#{token := Token}) -> Token.
+
+-spec user(session()) -> user().
+user(#{user := User}) -> User.
+
+-spec expires_at(session()) -> calendar:datetime().
+expires_at(#{expires_at := ExpiresAt}) -> ExpiresAt.
+
+generate_token() -> base64:encode(crypto:strong_rand_bytes(32)).

--- a/test/sr_test/sr_sessions_handler.erl
+++ b/test/sr_test/sr_sessions_handler.erl
@@ -35,6 +35,7 @@ trails() ->
   Path = "/sessions",
   Opts = #{ path => Path
           , model => sr_sessions
+          , verbose => true
           },
   [trails:trail(Path, ?MODULE, Opts, Metadata)].
 

--- a/test/sr_test/sr_sessions_handler.erl
+++ b/test/sr_test/sr_sessions_handler.erl
@@ -10,7 +10,6 @@
           , allowed_methods/2
           , resource_exists/2
           , content_types_provided/2
-          , handle_exception/3
           ]
         }]).
 
@@ -63,17 +62,13 @@ content_types_accepted(Req, State) ->
 -spec handle_post(cowboy_req:req(), state()) ->
   {{true, binary()}, cowboy_req:req(), state()}.
 handle_post(Req, State) ->
-  try
-    #{user := {User, _}} = State,
-    Session = sumo:persist(sr_sessions, sr_sessions:new(User)),
-    ResBody = sr_json:encode(sr_sessions:to_json(Session)),
-    Req1 = cowboy_req:set_resp_body(ResBody, Req),
-    SessionId = sr_sessions:uri_path(Session),
-    Location = <<"/sessions/", SessionId/binary>>,
-    {{true, Location}, Req1, State}
-  catch
-    _:Exception -> handle_exception(Exception, Req, State)
-  end.
+  #{user := {User, _}} = State,
+  Session = sumo:persist(sr_sessions, sr_sessions:new(User)),
+  ResBody = sr_json:encode(sr_sessions:to_json(Session)),
+  Req1 = cowboy_req:set_resp_body(ResBody, Req),
+  SessionId = sr_sessions:uri_path(Session),
+  Location = <<"/sessions/", SessionId/binary>>,
+  {{true, Location}, Req1, State}.
 
 -spec get_authorization(cowboy_req:req()) ->
     {{binary(), binary()}, cowboy_req:req()}

--- a/test/sr_test/sr_sessions_handler.erl
+++ b/test/sr_test/sr_sessions_handler.erl
@@ -1,0 +1,101 @@
+%%% @doc POST /sessions handler
+-module(sr_sessions_handler).
+
+-behaviour(trails_handler).
+
+-include_lib("mixer/include/mixer.hrl").
+-mixin([{ sr_entities_handler
+        , [ init/3
+          , rest_init/2
+          , allowed_methods/2
+          , resource_exists/2
+          , content_types_provided/2
+          , handle_exception/3
+          ]
+        }]).
+
+-export([ trails/0
+        , is_authorized/2
+        , content_types_accepted/2
+        , handle_post/2
+        ]).
+
+-type state() :: sr_entities_handler:state().
+
+-spec trails() -> trails:trails().
+trails() ->
+  Metadata =
+    #{ post =>
+       #{ tags => ["sessions"]
+        , description => "Creates a new session"
+        , consumes => ["application/json"]
+        , produces => ["application/json"]
+        }
+     },
+  Path = "/sessions",
+  Opts = #{ path => Path
+          , model => sr_sessions
+          },
+  [trails:trail(Path, ?MODULE, Opts, Metadata)].
+
+-spec is_authorized(cowboy_req:req(), state()) ->
+  {boolean(), cowboy_req:req(), state()}.
+is_authorized(Req, State) ->
+  case get_authorization(Req) of
+    {not_authenticated, Req1} ->
+      {{false, auth_header()}, Req1, State};
+    {User, Req1} ->
+      Users = application:get_env(sr_test, users, []),
+      case lists:member(User, Users) of
+        true -> {true, Req1, State#{user => User}};
+        false ->
+          ct:pal("Invalid user ~p not in ~p", [User, Users]),
+          {{false, auth_header()}, Req1, State}
+      end
+  end.
+
+-spec content_types_accepted(cowboy_req:req(), state()) ->
+  {[{'*', atom()}], cowboy_req:req(), state()}.
+content_types_accepted(Req, State) ->
+  {[{'*', handle_post}], Req, State}.
+
+-spec handle_post(cowboy_req:req(), state()) ->
+  {{true, binary()}, cowboy_req:req(), state()}.
+handle_post(Req, State) ->
+  try
+    #{user := {User, _}} = State,
+    Session = sumo:persist(sr_sessions, sr_sessions:new(User)),
+    ResBody = sr_json:encode(sr_sessions:to_json(Session)),
+    Req1 = cowboy_req:set_resp_body(ResBody, Req),
+    SessionId = sr_sessions:uri_path(Session),
+    Location = <<"/sessions/", SessionId/binary>>,
+    {{true, Location}, Req1, State}
+  catch
+    _:Exception -> handle_exception(Exception, Req, State)
+  end.
+
+-spec get_authorization(cowboy_req:req()) ->
+    {{binary(), binary()}, cowboy_req:req()}
+  | {not_authenticated, cowboy_req:req()}.
+get_authorization(Req) ->
+  try cowboy_req:parse_header(<<"authorization">>, Req) of
+    {ok, {<<"basic">>, {Key, Secret}}, Req1} ->
+      {{Key, Secret}, Req1};
+    {ok, Value, Req1} ->
+      WarnMsg = "Invalid basic authentication: ~p~n",
+      error_logger:warning_msg(WarnMsg, [Value]),
+      {not_authenticated, Req1};
+    {error, badarg} ->
+      {Hdr, Req1} = cowboy_req:header(<<"authorization">>, Req),
+      WarnMsg = "Malformed authorization header: ~p~n",
+      error_logger:warning_msg(WarnMsg, [Hdr]),
+      {not_authenticated, Req1}
+  catch
+    _:Error ->
+      WarnMsg = "Error trying to parse auth: ~p~nStack: ~s",
+      error_logger:warning_msg(WarnMsg, [Error, ktn_debug:ppst()]),
+      {not_authenticated, Req}
+  end.
+
+-spec auth_header() -> binary().
+auth_header() -> <<"Basic Realm=\"Sumo Rest Test\"">>.

--- a/test/sr_test/sr_single_session_handler.erl
+++ b/test/sr_test/sr_single_session_handler.erl
@@ -1,0 +1,49 @@
+%%% @doc GET|DELETE /sessions/:id handler
+-module(sr_single_session_handler).
+
+-behaviour(trails_handler).
+
+-include_lib("mixer/include/mixer.hrl").
+-mixin([{ sr_single_entity_handler
+        , [ init/3
+          , rest_init/2
+          , allowed_methods/2
+          , resource_exists/2
+          , content_types_accepted/2
+          , content_types_provided/2
+          , handle_get/2
+          , handle_put/2
+          , delete_resource/2
+          ]
+        }]).
+
+-export([ trails/0
+        ]).
+
+-spec trails() -> trails:trails().
+trails() ->
+  Id =
+    #{ name => id
+     , in => path
+     , description => <<"Session Id">>
+     , required => true
+     , type => string
+     },
+  Metadata =
+    #{ get =>
+       #{ tags => ["sessions"]
+        , description => "Returns a session"
+        , produces => ["application/json"]
+        , parameters => [Id]
+        }
+     , delete =>
+       #{ tags => ["sessions"]
+        , description => "Deletes a session"
+        , parameters => [Id]
+        }
+     },
+  Path = "/sessions/:id",
+  Opts = #{ path => Path
+          , model => sr_sessions
+          },
+  [trails:trail(Path, ?MODULE, Opts, Metadata)].

--- a/test/sr_test/sr_test.erl
+++ b/test/sr_test/sr_test.erl
@@ -33,6 +33,8 @@ start_phase(start_cowboy_listeners, _StartType, []) ->
   Handlers =
     [ sr_elements_handler
     , sr_single_element_handler
+    , sr_sessions_handler
+    , sr_single_session_handler
     , cowboy_swagger_handler
     ],
   Routes = trails:trails(Handlers),

--- a/test/test.config
+++ b/test/test.config
@@ -24,9 +24,15 @@
     , {storage_backends, []}
     , {stores, [{sr_store_mnesia, sumo_store_mnesia, [{workers, 10}]}]}
     , { docs
-      , [{sr_elements, sr_store_mnesia}]
+      , [ {sr_elements, sr_store_mnesia}
+        , {sr_sessions, sr_store_mnesia}
+        ]
       }
     , {events, []}
+    ]
+  }
+, { sr_test
+  , [ {users, [{<<"user1">>, <<"pwd1">>}, {<<"user2">>, <<"pwd2">>}]}
     ]
   }
 ].


### PR DESCRIPTION
Remember to test that `PUT /entities/:id`allows for the redefinition of `is_conflict` so that the user can forbid someone from creating new entities
