### PR TITLE
Invalid Content-Type for error responses

### DIFF
--- a/src/sr_entities_handler.erl
+++ b/src/sr_entities_handler.erl
@@ -83,17 +83,20 @@ handle_post(Req, State) ->
     Json             = sr_json:decode(Body),
     case Model:from_json(Json) of
       {error, Reason} ->
-        Req2 = cowboy_req:set_resp_body(Reason, Req1),
+        Req2 = cowboy_req:set_resp_body(sr_json:error(Reason), Req1),
         {false, Req2, State};
       {ok, Entity} ->
         handle_post(Entity, Req1, State)
     end
   catch
     _:conflict ->
-      {ok, Req3} = cowboy_req:reply(409, [], <<"Duplicated entity">>, Req),
+      {ok, Req3} =
+        cowboy_req:reply(409, [], sr_json:error(<<"Duplicated entity">>), Req),
       {halt, Req3, State};
     _:badjson ->
-      Req3 = cowboy_req:set_resp_body(<<"Malformed JSON request">>, Req),
+      Req3 =
+        cowboy_req:set_resp_body(
+          sr_json:error(<<"Malformed JSON request">>), Req),
       {false, Req3, State}
   end.
 

--- a/src/sr_json.erl
+++ b/src/sr_json.erl
@@ -4,6 +4,7 @@
 -export([encode/1, decode/1]).
 -export([encode_date/1, decode_date/1]).
 -export([encode_null/1, decode_null/1]).
+-export([error/1]).
 
 -type key() :: binary() | atom().
 -type object() :: #{key() => json()}.
@@ -50,3 +51,6 @@ encode_null(Json) -> Json.
                ; (non_null_json()) -> json().
 decode_null(null) -> undefined;
 decode_null(Json) -> Json.
+
+-spec error(binary()) -> iodata().
+error(Error) -> encode(#{error => Error}).

--- a/src/sr_single_entity_handler.erl
+++ b/src/sr_single_entity_handler.erl
@@ -75,7 +75,9 @@ handle_patch(Req, #{entity := Entity} = State) ->
     persist(Model:update(Entity, Json), Req1, State)
   catch
     _:badjson ->
-      Req3 = cowboy_req:set_resp_body(<<"Malformed JSON request">>, Req),
+      Req3 =
+        cowboy_req:set_resp_body(
+          sr_json:error(<<"Malformed JSON request">>), Req),
       {false, Req3, State}
   end.
 
@@ -89,7 +91,9 @@ handle_put(Req, #{entity := Entity} = State) ->
     persist(Model:update(Entity, Json), Req1, State)
   catch
     _:badjson ->
-      Req3 = cowboy_req:set_resp_body(<<"Malformed JSON request">>, Req),
+      Req3 =
+        cowboy_req:set_resp_body(
+          sr_json:error(<<"Malformed JSON request">>), Req),
       {false, Req3, State}
   end;
 handle_put(Req, #{id := Id} = State) ->
@@ -100,7 +104,9 @@ handle_put(Req, #{id := Id} = State) ->
     persist(from_json(Model, Id, Json), Req1, State)
   catch
     _:badjson ->
-      Req3 = cowboy_req:set_resp_body(<<"Malformed JSON request">>, Req),
+      Req3 =
+        cowboy_req:set_resp_body(
+          sr_json:error(<<"Malformed JSON request">>), Req),
       {false, Req3, State}
   end.
 

--- a/test/sr_test/sr_sessions_handler.erl
+++ b/test/sr_test/sr_sessions_handler.erl
@@ -96,7 +96,7 @@ handle_post(Req, State) ->
     Json             = sr_json:decode(Body),
     case sr_sessions:from_json(Json) of
       {error, Reason} ->
-        Req2 = cowboy_req:set_resp_body(Reason, Req1),
+        Req2 = cowboy_req:set_resp_body(sr_json:error(Reason), Req1),
         {false, Req2, State};
       {ok, Session} ->
         FullSession = sr_sessions:user(Session, User),
@@ -104,9 +104,12 @@ handle_post(Req, State) ->
     end
   catch
     _:conflict ->
-      {ok, Req3} = cowboy_req:reply(409, [], <<"Duplicated entity">>, Req),
+      {ok, Req3} =
+        cowboy_req:reply(409, [], sr_json:error(<<"Duplicated entity">>), Req),
       {halt, Req3, State};
     _:badjson ->
-      Req3 = cowboy_req:set_resp_body(<<"Malformed JSON request">>, Req),
+      Req3 =
+        cowboy_req:set_resp_body(
+          sr_json:error(<<"Malformed JSON request">>), Req),
       {false, Req3, State}
   end.


### PR DESCRIPTION
Error responses, like `Malformed JSON request` are provided as plain text but the `content-type` header says `application/json`
