### PR TITLE
Handle params in query-string

### DIFF
--- a/src/sr_entities_handler.erl
+++ b/src/sr_entities_handler.erl
@@ -117,7 +117,14 @@ handle_get(Req, State) ->
   {Qs, Req1} = cowboy_req:qs_vals(Req),
   Conditions = [ {binary_to_atom(Name, unicode),
     Value} || {Name, Value} <- Qs ],
-  Entities = case Conditions of
+  Schema = sumo_internal:get_schema(Model),
+  Fields = [ sumo_internal:field_name(Field) ||
+      Field <- sumo_internal:schema_fields(Schema) ],
+  CompareFun = fun({Name, _}) ->
+    true =:= lists:member(Name, Fields)
+  end,
+  ValidConditions = lists:filter(CompareFun, Conditions),
+  Entities = case ValidConditions of
     [] -> sumo:find_all(Model);
     _  -> sumo:find_by(Model, Conditions)
   end,

--- a/test/sr_elements_SUITE.erl
+++ b/test/sr_elements_SUITE.erl
@@ -55,6 +55,15 @@ success_scenario(_Config) ->
    , <<"updated_at">> := CreatedAt
    } = Element1 = sr_json:decode(Body1),
 
+  ct:comment("Find element using query string"),
+  #{status_code := 200, body := BodyA} =
+    sr_test_utils:api_call(get, "/elements?value=val1"),
+  [#{ <<"created_at">> := CreatedAt
+   , <<"key">>        := <<"element1">>
+   , <<"updated_at">> := CreatedAt
+   , <<"value">>      := <<"val1">>
+   }] = sr_json:decode(BodyA),
+
   ct:comment("Element 1 is modified"),
   #{status_code := 409, body := Body01} =
     sr_test_utils:api_call(

--- a/test/sr_elements_SUITE.erl
+++ b/test/sr_elements_SUITE.erl
@@ -64,6 +64,11 @@ success_scenario(_Config) ->
    , <<"value">>      := <<"val1">>
    }] = sr_json:decode(BodyA),
 
+  ct:comment("Find elements non existent value using query string"),
+  #{status_code := 200, body := BodyB} =
+    sr_test_utils:api_call(get, "/elements?novalue=noval"),
+  [Element1] = sr_json:decode(BodyB),
+
   ct:comment("Element 1 is modified"),
   #{status_code := 409, body := Body01} =
     sr_test_utils:api_call(


### PR DESCRIPTION
Fixes #8 
- handle params in query-string
- pass params as conditions
- if param is not present in model then skip
