### PR TITLE
Properly differentiate between sumo_db's models and modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ We've chosen **Mnesia** as our backend, so we just enabled debug on it (not a re
     , {storage_backends, []}
     , {stores, [{sr_store_mnesia, sumo_store_mnesia, [{workers, 10}]}]}
     , { docs
-      , [ {sr_elements, sr_store_mnesia}
-        , {sr_sessions, sr_store_mnesia}
+      , [ {elements, sr_store_mnesia, #{module => sr_elements}}
+        , {sessions, sr_store_mnesia, #{module => sr_sessions}}
         ]
       }
     , {events, []}
@@ -183,7 +183,7 @@ The next step is to define our models (i.e. the entities our system will manage)
 ```erlang
 -spec sumo_schema() -> sumo:schema().
 sumo_schema() ->
-  sumo:new_schema(?MODULE,
+  sumo:new_schema(elements,
     [ sumo:new_field(key,        string,   [id, not_null])
     , sumo:new_field(value,      string,   [not_null])
     , sumo:new_field(created_at, datetime, [not_null])
@@ -307,7 +307,7 @@ trails() ->
      },
   Path = "/elements",
   Opts = #{ path => Path
-          , model => sr_elements
+          , model => elements
           },
   [trails:trail(Path, ?MODULE, Opts, Metadata)].
 ```
@@ -385,7 +385,7 @@ But we needed to prevent users from accessing other user's sessions, so we imple
   {boolean(), cowboy_req:req(), state()}.
 forbidden(Req, State) ->
   #{user := {User, _}, id := Id} = State,
-  case sumo:find(sr_sessions, Id) of
+  case sumo:find(sessions, Id) of
     notfound -> {false, Req, State};
     Session -> {User =/= sr_sessions:user(Session), Req, State}
   end.

--- a/rebar.config
+++ b/rebar.config
@@ -87,6 +87,9 @@
   {subpackages, false}
 ]}.
 
+%% == Xref ==
+{xref_checks, [undefined_function_calls, locals_not_used, deprecated_function_calls]}.
+
 %% == Dialyzer ==
 
 {dialyzer, [

--- a/test/sr_elements_SUITE.erl
+++ b/test/sr_elements_SUITE.erl
@@ -26,7 +26,7 @@ all() -> sr_test_utils:all(?MODULE).
 -spec init_per_testcase(atom(), sr_test_utils:config()) ->
   sr_test_utils:config().
 init_per_testcase(_, Config) ->
-  _ = sumo:delete_all(sr_elements),
+  _ = sumo:delete_all(elements),
   Config.
 
 -spec end_per_testcase(atom(), sr_test_utils:config()) ->
@@ -215,7 +215,7 @@ invalid_headers(_Config) ->
 -spec invalid_parameters(sr_test_utils:config()) -> {comment, string()}.
 invalid_parameters(_Config) ->
   Headers = #{<<"content-type">> => <<"application/json">>},
-  _ = sumo:persist(sr_elements, sr_elements:new(<<"key">>, <<"val">>)),
+  _ = sumo:persist(elements, sr_elements:new(<<"key">>, <<"val">>)),
 
   ct:comment("Empty or broken parameters are reported"),
   #{status_code := 400} =

--- a/test/sr_test/sr_elements.erl
+++ b/test/sr_test/sr_elements.erl
@@ -45,7 +45,7 @@
 
 -spec sumo_schema() -> sumo:schema().
 sumo_schema() ->
-  sumo:new_schema(?MODULE,
+  sumo:new_schema(elements,
     [ sumo:new_field(key,        string,   [id, not_null])
     , sumo:new_field(value,      string,   [not_null])
     , sumo:new_field(created_at, datetime, [not_null])

--- a/test/sr_test/sr_elements_handler.erl
+++ b/test/sr_test/sr_elements_handler.erl
@@ -49,6 +49,6 @@ trails() ->
      },
   Path = "/elements",
   Opts = #{ path => Path
-          , model => sr_elements
+          , model => elements
           },
   [trails:trail(Path, ?MODULE, Opts, Metadata)].

--- a/test/sr_test/sr_sessions.erl
+++ b/test/sr_test/sr_sessions.erl
@@ -53,7 +53,7 @@
 
 -spec sumo_schema() -> sumo:schema().
 sumo_schema() ->
-  sumo:new_schema(?MODULE,
+  sumo:new_schema(sessions,
     [ sumo:new_field(id,          binary,   [id, not_null])
     , sumo:new_field(token,       binary,   [not_null])
     , sumo:new_field(agent,       binary,   [])

--- a/test/sr_test/sr_sessions_handler.erl
+++ b/test/sr_test/sr_sessions_handler.erl
@@ -40,7 +40,7 @@ trails() ->
      },
   Path = "/sessions",
   Opts = #{ path => Path
-          , model => sr_sessions
+          , model => sessions
           , verbose => true
           },
   [trails:trail(Path, ?MODULE, Opts, Metadata)].
@@ -90,7 +90,7 @@ auth_header() -> <<"Basic Realm=\"Sumo Rest Test\"">>.
 -spec handle_post(cowboy_req:req(), map()) ->
   {{true, binary()} | false | halt, cowboy_req:req(), state()}.
 handle_post(Req, #{opts := Opts} = State) ->
-  #{user := {User, _}} = State,
+  #{user := {User, _}, module := Module} = State,
   try
     {ok, Body, Req1} = cowboy_req:body(Req),
     Json             = sr_json:decode(Body),
@@ -100,7 +100,7 @@ handle_post(Req, #{opts := Opts} = State) ->
         {false, Req2, State};
       {ok, Session} ->
         FullSession = sr_sessions:user(Session, User),
-        State2 = #{opts => Opts},
+        State2 = #{opts => Opts, module => Module},
         sr_entities_handler:handle_post(FullSession, Req1, State2)
     end
   catch

--- a/test/sr_test/sr_single_element_handler.erl
+++ b/test/sr_test/sr_single_element_handler.erl
@@ -65,6 +65,6 @@ trails() ->
      },
   Path = "/elements/:id",
   Opts = #{ path => Path
-          , model => sr_elements
+          , model => elements
           },
   [trails:trail(Path, ?MODULE, Opts, Metadata)].

--- a/test/sr_test/sr_single_session_handler.erl
+++ b/test/sr_test/sr_single_session_handler.erl
@@ -59,7 +59,7 @@ trails() ->
      },
   Path = "/sessions/:id",
   Opts = #{ path => Path
-          , model => sr_sessions
+          , model => sessions
           , verbose => true
           },
   [trails:trail(Path, ?MODULE, Opts, Metadata)].
@@ -68,7 +68,7 @@ trails() ->
   {boolean(), cowboy_req:req(), map()}.
 forbidden(Req, State) ->
   #{user := {User, _}, id := Id} = State,
-  case sumo:find(sr_sessions, Id) of
+  case sumo:find(sessions, Id) of
     notfound -> {false, Req, State};
     Session -> {User =/= sr_sessions:user(Session), Req, State}
   end.

--- a/test/test.config
+++ b/test/test.config
@@ -30,8 +30,8 @@
         ]}
       ]}
     , { docs
-      , [ {sr_elements, sr_store_mnesia, #{module => sr_elements}}
-        , {sr_sessions, sr_store_mnesia, #{module => sr_sessions}}
+      , [ {elements, sr_store_mnesia, #{module => sr_elements}}
+        , {sessions, sr_store_mnesia, #{module => sr_sessions}}
         ]
       }
     , {events, []}


### PR DESCRIPTION
Since sumo_db's 0.6.1, models can have different names than their modules.
SumoREST is not considering that and it's still trying to do, for instance `Model:from_json(…)`.
