### PR TITLE
List mnesia as dependency of test application

### DIFF
--- a/test/sr_test.app
+++ b/test/sr_test.app
@@ -10,6 +10,7 @@
     , cowboy_swagger
     , jiffy
     , sumo_db
+    , mnesia
     ]},
   {modules, []},
   {mod, {sr_test, []}},


### PR DESCRIPTION
Please refer to commit message for details.

I understand the sr_test application does not have a structured way for building it as an OTP release e.g. its own rebar.config. I expect that if application sr_test were built as an OTP release without listing mnesia in rebar.config then the OTP release would fail to start for missing mnesia.