### PR TITLE
Highlight the role of the `:id` binding in cowboy route

### DIFF
--- a/src/sr_request.erl
+++ b/src/sr_request.erl
@@ -11,11 +11,13 @@
 %%% Types
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+-type binding_name() :: id | atom().
+
 -opaque req() ::
   #{ body     := sr_json:json()
    , headers  := [{binary(), iodata()}]
    , path     := binary()
-   , bindings := #{atom() => any()}
+   , bindings := #{binding_name() => any()}
    }.
 
 -export_type [req/0].


### PR DESCRIPTION
Does the name of the parameter in the Swagger schema e.g. [this](https://github.com/inaka/sumo_rest/blob/0.3.3/test/sr_test/sr_single_element_handler.erl#L33) need to be called `id` e.g. in case cowboy_swagger enforces it?
* If not, examples [here](https://github.com/inaka/sumo_rest/blob/0.3.3/test/sr_test/sr_single_session_handler.erl) and [here](https://github.com/inaka/sumo_rest/blob/0.3.3/test/sr_test/sr_single_element_handler.erl) would benefit from clarification on that;
* I did not test that, and I do not plan to test the Swagger handler for the moment.

Please refer to the commit message for details.

See also https://github.com/inaka/sumo_db/pull/294