### PR TITLE
Refine type of JSON decoding input

### DIFF
--- a/src/sr_json.erl
+++ b/src/sr_json.erl
@@ -29,7 +29,7 @@
 encode(Json) -> jsx:encode(Json, [uescape]).
 
 %% @doc String to internal representation
--spec decode(iodata()) -> json().
+-spec decode(binary()) -> json().
 decode(Data) ->
   try jsx:decode(Data, [return_maps])
   catch


### PR DESCRIPTION
Please refer to commit message for details.

I noticed this mismatch and I thought appropriate opening PR. I did not investigate impact i.e. if any caller assumed the more relaxed type.

The alternative to this PR is calling [`iolist_to_binary/1`](http://erlang.org/doc/man/erlang.html#iolist_to_binary-1) on the input.